### PR TITLE
feat: Add `exportmetadata` command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 mod_version=1.2.5
 minecraft_version=1.20.1
 forge_version=47.0.1
-cyclopscore_version=1.18.4-340
+cyclopscore_version=1.18.14-403
 release_type=release
 fingerprint=bd0353b3e8a2810d60dd584e256e364bc3bedd44
 

--- a/src/main/java/org/cyclops/iconexporter/IconExporter.java
+++ b/src/main/java/org/cyclops/iconexporter/IconExporter.java
@@ -10,6 +10,7 @@ import org.cyclops.cyclopscore.init.ModBaseVersionable;
 import org.cyclops.cyclopscore.proxy.IClientProxy;
 import org.cyclops.cyclopscore.proxy.ICommonProxy;
 import org.cyclops.iconexporter.command.CommandExport;
+import org.cyclops.iconexporter.command.CommandExportMetadata;
 import org.cyclops.iconexporter.proxy.ClientProxy;
 import org.cyclops.iconexporter.proxy.CommonProxy;
 
@@ -36,6 +37,7 @@ public class IconExporter extends ModBaseVersionable<IconExporter> {
 
         if (FMLEnvironment.dist.isClient()) {
             root.then(CommandExport.make());
+            root.then(CommandExportMetadata.make());
         }
 
         return root;

--- a/src/main/java/org/cyclops/iconexporter/client/gui/ImageExportUtil.java
+++ b/src/main/java/org/cyclops/iconexporter/client/gui/ImageExportUtil.java
@@ -5,8 +5,14 @@ import net.minecraft.client.Minecraft;
 import com.mojang.blaze3d.platform.NativeImage;
 import net.minecraft.nbt.Tag;
 import net.minecraft.client.Screenshot;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
+import org.cyclops.iconexporter.GeneralConfig;
 import org.cyclops.iconexporter.IconExporter;
 import org.lwjgl.system.MemoryUtil;
 
@@ -19,7 +25,26 @@ import java.io.IOException;
  */
 public class ImageExportUtil {
 
-    public static void exportImageFromScreenshot(File dir, String key, int scaleImage, int backgroundColor) throws IOException {
+    public static String genBaseFilenameFromFluid(ResourceKey<Fluid> fluid) {
+        StringBuffer sb = new StringBuffer("fluid__");
+        sb.append(fluid.location());
+        return sb.toString().replaceAll(":", "__").replaceAll("\"", "'");
+    }
+    public static String genBaseFilenameFromItem(ItemStack itemStack) {
+        StringBuffer sb = new StringBuffer();
+        sb.append(ForgeRegistries.ITEMS.getKey(itemStack.getItem()));
+        if(itemStack.hasTag()) {
+            sb.append("__");
+            if (GeneralConfig.fileNameHashTag) {
+                sb.append(DigestUtils.md5Hex(itemStack.getTag().toString()));
+            } else {
+                sb.append(itemStack.getTag());
+            }
+        }
+        return sb.toString().replaceAll(":", "__").replaceAll("\"", "'");
+    }
+
+    public static void exportImageFromScreenshot(File dir, String baseFilename, int scaleImage, int backgroundColor) throws IOException {
         // Take a screenshot
         NativeImage imageFull = Screenshot.takeScreenshot(Minecraft.getInstance().getMainRenderTarget());
         NativeImage image = getSubImage(imageFull, scaleImage, scaleImage);
@@ -41,12 +66,8 @@ public class ImageExportUtil {
             }
         }
 
-        // Write the file
-        key = key
-                .replaceAll(":", "__")
-                .replaceAll("\"", "'");
         try {
-            File file = new File(dir, key + ".png").getCanonicalFile();
+            File file = new File(dir, baseFilename + ".png").getCanonicalFile();
             try {
                 image.writeToFile(file);
             } catch (NullPointerException e) {
@@ -54,18 +75,17 @@ public class ImageExportUtil {
                 throw new IOException("Error while writing the PNG image " + file);
             }
         } catch (IOException e) {
-            IconExporter.clog(Level.ERROR, "Error while writing the PNG image for key " + key);
+            IconExporter.clog(Level.ERROR, "Error while writing the PNG image for name " + baseFilename);
             throw e;
         } finally {
             image.close();
         }
     }
 
-    public static void exportNbtFile(File dir, String key, Tag tag) throws IOException {
+    public static void exportNbtFile(File dir, String baseFilename, Tag tag) throws IOException {
         // Write the file
-        key = key.replaceAll(":", "__");
         try {
-            File file = new File(dir, key + ".txt").getCanonicalFile();
+            File file = new File(dir, baseFilename + ".txt").getCanonicalFile();
             try {
                 FileUtils.writeStringToFile(file, tag.toString(), Charsets.UTF_8);
             } catch (NullPointerException e) {
@@ -73,7 +93,7 @@ public class ImageExportUtil {
                 throw new IOException("Error while writing the TXT image " + file);
             }
         } catch (IOException e) {
-            IconExporter.clog(Level.ERROR, "Error while writing the TXT image for key " + key);
+            IconExporter.clog(Level.ERROR, "Error while writing the TXT image for name " + baseFilename);
             throw e;
         }
     }

--- a/src/main/java/org/cyclops/iconexporter/client/gui/ScreenIconExporter.java
+++ b/src/main/java/org/cyclops/iconexporter/client/gui/ScreenIconExporter.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.ItemStack;
@@ -91,13 +90,13 @@ public class ScreenIconExporter extends Screen {
         // Add fluids
         for (Map.Entry<ResourceKey<Fluid>, Fluid> fluidEntry : ForgeRegistries.FLUIDS.getEntries()) {
             tasks.set(tasks.get() + 1);
-            String subKey = "fluid:" + fluidEntry.getKey().location();
+            String baseFilename = ImageExportUtil.genBaseFilenameFromFluid(fluidEntry.getKey());
             exportTasks.add((guiGraphics) -> {
                 taskProcessed.set(taskProcessed.get() + 1);
                 signalStatus(tasks, taskProcessed);
                 guiGraphics.fill(0, 0, scaleModifiedRounded, scaleModifiedRounded, BACKGROUND_COLOR);
                 ItemRenderUtil.renderFluid(guiGraphics, fluidEntry.getValue(), scaleModified);
-                ImageExportUtil.exportImageFromScreenshot(baseDir, subKey, this.scaleImage, BACKGROUND_COLOR_SHIFTED);
+                ImageExportUtil.exportImageFromScreenshot(baseDir, baseFilename, this.scaleImage, BACKGROUND_COLOR_SHIFTED);
             });
         }
 
@@ -109,17 +108,16 @@ public class ScreenIconExporter extends Screen {
         );
         for (CreativeModeTab creativeModeTab : CreativeModeTabRegistry.getSortedCreativeModeTabs()) {
             for (ItemStack itemStack : creativeModeTab.getDisplayItems()) {
-                ResourceLocation key = ForgeRegistries.ITEMS.getKey(itemStack.getItem());
                 tasks.set(tasks.get() + 1);
-                String subKey = key + (itemStack.hasTag() ? "__" + serializeNbtTag(itemStack.getTag()) : "");
+                String baseFilename = ImageExportUtil.genBaseFilenameFromItem(itemStack);
                 exportTasks.add((guiGraphics) -> {
                     taskProcessed.set(taskProcessed.get() + 1);
                     signalStatus(tasks, taskProcessed);
                     guiGraphics.fill(0, 0, scaleModifiedRounded, scaleModifiedRounded, BACKGROUND_COLOR);
                     ItemRenderUtil.renderItem(guiGraphics, itemStack, scaleModified);
-                    ImageExportUtil.exportImageFromScreenshot(baseDir, subKey, this.scaleImage, BACKGROUND_COLOR_SHIFTED);
+                    ImageExportUtil.exportImageFromScreenshot(baseDir, baseFilename, this.scaleImage, BACKGROUND_COLOR_SHIFTED);
                     if (itemStack.hasTag() && GeneralConfig.fileNameHashTag) {
-                        ImageExportUtil.exportNbtFile(baseDir, subKey, itemStack.getTag());
+                        ImageExportUtil.exportNbtFile(baseDir, baseFilename, itemStack.getTag());
                     }
                 });
             }

--- a/src/main/java/org/cyclops/iconexporter/command/CommandExportMetadata.java
+++ b/src/main/java/org/cyclops/iconexporter/command/CommandExportMetadata.java
@@ -3,6 +3,7 @@ package org.cyclops.iconexporter.command;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
@@ -36,6 +37,7 @@ public class CommandExportMetadata implements Command<CommandSourceStack> {
 
     @Override
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        Gson gson = new Gson();
         JsonArray jsonMeta = new JsonArray();
 
         // Add items
@@ -50,6 +52,9 @@ public class CommandExportMetadata implements Command<CommandSourceStack> {
                 obj.addProperty("image_file", ImageExportUtil.genBaseFilenameFromItem(itemStack)+".png");
                 obj.addProperty("local_name", itemStack.getHoverName().getString());
                 obj.addProperty("id", ForgeRegistries.ITEMS.getKey(itemStack.getItem()).toString());
+                if (itemStack.hasTag()) {
+                    obj.add("nbt", JsonParser.parseString(itemStack.getTag().toString()));
+                }
                 obj.addProperty("type", "item");
                 jsonMeta.add(obj);
             }
@@ -69,7 +74,7 @@ public class CommandExportMetadata implements Command<CommandSourceStack> {
         json.add("meta", jsonMeta);
 
         // save the file
-        String jsonString = new Gson().toJson(json);
+        String jsonString = gson.toJson(json);
         File f = new File(Minecraft.getInstance().gameDirectory, "icon-exports-metadata.json");
         try {
             FileWriter writer = new FileWriter(f);

--- a/src/main/java/org/cyclops/iconexporter/command/CommandExportMetadata.java
+++ b/src/main/java/org/cyclops/iconexporter/command/CommandExportMetadata.java
@@ -1,0 +1,92 @@
+package org.cyclops.iconexporter.command;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.common.CreativeModeTabRegistry;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.cyclops.iconexporter.client.gui.ImageExportUtil;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A command to initiate the exporting process.
+ * @author rubensworks
+ *
+ */
+public class CommandExportMetadata implements Command<CommandSourceStack> {
+
+    public CommandExportMetadata() {}
+
+    @Override
+    public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        JsonArray jsonMeta = new JsonArray();
+
+        // Add items
+        CreativeModeTabs.tryRebuildTabContents(
+                Minecraft.getInstance().player.connection.enabledFeatures(),
+                Minecraft.getInstance().options.operatorItemsTab().get(),
+                Minecraft.getInstance().level.registryAccess()
+        );
+        for (CreativeModeTab creativeModeTab : CreativeModeTabRegistry.getSortedCreativeModeTabs()) {
+            for (ItemStack itemStack : creativeModeTab.getDisplayItems()) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty("image_file", ImageExportUtil.genBaseFilenameFromItem(itemStack)+".png");
+                obj.addProperty("local_name", itemStack.getHoverName().getString());
+                obj.addProperty("id", ForgeRegistries.ITEMS.getKey(itemStack.getItem()).toString());
+                obj.addProperty("type", "item");
+                jsonMeta.add(obj);
+            }
+        }
+
+        // Add fluids
+        for (Map.Entry<ResourceKey<Fluid>, Fluid> fluidEntry : ForgeRegistries.FLUIDS.getEntries()) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("image_file", ImageExportUtil.genBaseFilenameFromFluid(fluidEntry.getKey())+".png");
+            obj.addProperty("local_name", fluidEntry.getValue().getFluidType().getDescription().getString());
+            obj.addProperty("id", fluidEntry.getKey().location().toString());
+            obj.addProperty("type", "fluid");
+            jsonMeta.add(obj);
+        }
+
+        JsonObject json = new JsonObject();
+        json.add("meta", jsonMeta);
+
+        // save the file
+        String jsonString = new Gson().toJson(json);
+        File f = new File(Minecraft.getInstance().gameDirectory, "icon-exports-metadata.json");
+        try {
+            FileWriter writer = new FileWriter(f);
+            writer.write(jsonString);
+            writer.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Minecraft.getInstance().player.sendSystemMessage(Component.translatable("gui.itemexporter.metadata_export.success", f.getAbsolutePath()));
+
+        return 0;
+    }
+
+    public static LiteralArgumentBuilder<CommandSourceStack> make() {
+        return Commands.literal("exportmetadata")
+                .executes(new CommandExportMetadata());
+    }
+
+}

--- a/src/main/resources/assets/iconexporter/lang/en_us.json
+++ b/src/main/resources/assets/iconexporter/lang/en_us.json
@@ -3,5 +3,6 @@
   "gui.itemexporter.name": "Icon Exporter",
   "gui.itemexporter.finished": "Finished exporting",
   "gui.itemexporter.error": "Error while exporting",
-  "gui.itemexporter.status": "Rendering %s / %s"
+  "gui.itemexporter.status": "Rendering %s / %s",
+  "gui.itemexporter.metadata_export.success": "Exported metadata file to %s"
 }


### PR DESCRIPTION
This PR does what I proposed here: https://github.com/CyclopsMC/IconExporter/issues/6#issuecomment-2030633477 , but is more general, to allow export of NBT and item ID

In addition to fixing https://github.com/CyclopsMC/IconExporter/issues/6, this will also allow me to greatly simplify the script I currently use to recover item IDs from their filename: https://github.com/iTrooz/AppliedOverInternet/blob/1e4fc049aa775740e40ce22e33834110ef311815/reorder.py