### PR TITLE
Scale the icon pose uniformly so block icons keep their shading

### DIFF
--- a/loader-common/src/main/java/org/cyclops/iconexporter/client/gui/ItemRenderUtil.java
+++ b/loader-common/src/main/java/org/cyclops/iconexporter/client/gui/ItemRenderUtil.java
@@ -41,7 +41,11 @@ public class ItemRenderUtil {
 
     protected static void renderGuiItem(PoseStack p_275246_, ItemStack p_275195_, int p_275214_, int p_275658_, BakedModel p_275740_, float scale) {
         p_275246_.pushPose();
-        p_275246_.scale(scale / 16, scale / 16, 1);
+        // This scaling must be uniform: PoseStack#scale reacts to a non-uniform scale by scaling the
+        // normal matrix by the inverse of it, which squashes every vertex normal and flattens the
+        // diffuse lighting of 3D (block) models. Exported block icons then come out significantly
+        // darker than the same block looks in the inventory.
+        p_275246_.scale(scale / 16, scale / 16, scale / 16);
         p_275246_.translate((float)p_275214_, (float)p_275658_, 100.0F);
         p_275246_.translate(8.0F, 8.0F, 0.0F);
         p_275246_.mulPose((new Matrix4f()).scaling(1.0F, -1.0F, 1.0F));


### PR DESCRIPTION
Exported block icons come out ~30% darker than the same block looks in the vanilla inventory, while flat (2D) item icons are fine.

## Cause

`ItemRenderUtil#renderGuiItem` scales the pose by `(f, f, 1)` to reach the requested icon size, with `f = (iconSize / guiScale) / 16`:

```java
p_275246_.scale(scale / 16, scale / 16, 1);
```

`PoseStack#scale` reacts to a **non-uniform** scale by scaling the normal matrix by the inverse and marking the normals as untrusted, so every vertex normal gets its X and Y components squashed. That flattens the diffuse part of Minecraft's GUI lighting (the 0.4 ambient part is unaffected), which costs 3D block models most of their shading. Flat item sprites face the camera, so they are unaffected — which is why only block icons look wrong.

Dumping the pose that `renderGuiItem` builds, next to the one vanilla's `ItemRenderer#renderGuiItem` builds (MC 1.21.1 `PoseStack`, block `gui` display transform applied):

```
vanilla                  trustedNormals=true   normal=[-0.707 0 -0.707; 0.354 -0.866 -0.354; 0.612 0.5 -0.612]
scale(f,f,1)  f=1        trustedNormals=true   normal=[-0.707 0 -0.707; 0.354 -0.866 -0.354; 0.612 0.5 -0.612]
scale(f,f,1)  f=2        trustedNormals=false  normal=[-0.354 0 -0.354; 0.177 -0.433 -0.177; 0.612 0.5 -0.612]
scale(f,f,f)  any f      trustedNormals=true   normal=[-0.707 0 -0.707; 0.354 -0.866 -0.354; 0.612 0.5 -0.612]
```

## Fix

Scale uniformly. The pose is then identical to vanilla's for any icon size and GUI scale, so the icons are shaded exactly like the inventory. `renderFluid` right below already scales uniformly.

Since the scaling is orthographic and the item's Z extent scales along with its position, this does not change what is visible — only the normals.

## Measurements

Exported with a headless client (NeoForge 21.1.210, MC 1.21.1) and measured on the three visible faces of full-cube vanilla blocks (dirt, stone, gold_block, oak_planks, netherrack, sand, iron_block, bricks), as a fraction of the block texture's brightness. Vanilla's own inventory renders sit at 0.99 / 0.65 / 0.40.

Same game session and GUI scale, varying only the requested icon size (so only `f` changes):

| `f` | top | left | right |
| --- | --- | --- | --- |
| 1 | 0.975 | 0.634 | 0.396 |
| 2 | 0.687 | 0.466 | 0.391 |
| 4 | 0.566 | 0.418 | 0.397 |
| vanilla | 0.990 | 0.650 | 0.400 |

At `f = 1` the export already matches vanilla, and this change makes every icon size behave like `f = 1`.

I could not build the mod in my environment, so this is verified against Minecraft's real `PoseStack` (the dump above) plus the in-game measurements, rather than by an export from a build of this branch.

## Other branches

`master-1.21.4` has the same defect in a shorter form (`gui.pose().scale(scale / 16, scale / 16, 1)` around `gui.renderItem`, with `renderFluid` next to it already uniform). `master-1.21`, `master-1.21.8`, `master-1.21.10` and `master-26` use the 2D pose of the newer GUI pipeline and are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FpcjAK5qKkXRQHQfwjWnz

---
_Generated by [Claude Code](https://claude.ai/code/session_013FpcjAK5qKkXRQHQfwjWnz)_